### PR TITLE
HAP Protocol defines mDNS TXT record md= to mean model name, not device name

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3078,6 +3078,14 @@ void homekit_setup_mdns(homekit_server_t *server) {
         return;
     }
 
+    homekit_characteristic_t *model =
+        homekit_service_characteristic_by_type(accessory_info, HOMEKIT_CHARACTERISTIC_MODEL);
+    if (!model) {
+        ERROR("Invalid accessory declaration: "
+              "no Model characteristic in AccessoryInfo service");
+        return;
+    }
+
     char txt_rec[128];
     txt_rec[0] = 0;
 
@@ -3095,7 +3103,7 @@ void homekit_setup_mdns(homekit_server_t *server) {
     }
 
     // accessory model name (required)
-    add_txt("md=%s", name->value.string_value);
+    add_txt("md=%s", model->value.string_value);
     // protocol version (required)
     add_txt("pv=1.0");
     // device ID (required)


### PR DESCRIPTION
I have implemented device names that include partial MAC addresses as in the `accessory_name` example and then tried to mDNS to discover all devices with my model name on the network and noticed that the `md=` `TXT` record is set to the Accessory `Name` characteristic instead of the `Model` characteristic. After reading section 5.4 of the HAP protocol document, Table 5-7 defines `md=` to be the model name.  

The mDNS facility name is correctly set to the accessory name in the code which matches the protocol document in the first paragraph of section 5.4 so that is awesome.

This change would allow us to discover all devices of a particular model on the network. I'm using this to discover all devices of the correct model to then use `rboot-api` and `ota-tftp` to update the firmware on the network only to the correct devices.