### PR TITLE
Increase maximum buffer for mDNS packets to 1.5KB.

### DIFF
--- a/src/mdnsresponder.h
+++ b/src/mdnsresponder.h
@@ -18,7 +18,7 @@
 
 /* The default maximum reply size, increase as necessary. */
 #ifndef MDNS_RESPONDER_REPLY_SIZE
-#define MDNS_RESPONDER_REPLY_SIZE      512
+#define MDNS_RESPONDER_REPLY_SIZE      1536
 #endif
 
 // Starts the mDNS responder task, call first


### PR DESCRIPTION
The mDNS packets used in HomeKit scale linearly in size with the number of HomeKit devices. With dozens of HomeKit devices, we blow right through the 512B packet buffer currently set as default. Increasing that default to 1.5K works around the issue entirely, empirically, and shouldn't have any lasting memory effect since these buffers live only within respective mDNS callbacks.

Of course, I could do this on a case-by-case basis via CFLAGS, but I suspect that the intent is that the default handles most usual cases. I'm not sure at what point HomeKit clients will split up the mDNS requests, but I decided not to dig further into it upon finding that 1.5K was enough to handle any amount of devices I could throw at it -- tested ~30 or so. My suspicion is that iOS devices will impose an MTU of <1.5K when serializing mDNS.