### PR TITLE
Change MDNS_TTL from 60 to 4500 secs by default

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -8,7 +8,9 @@
 #include <esplibs/libmain.h>
 #include "mdnsresponder.h"
 
-#define MDNS_TTL 60
+#ifndef MDNS_TTL
+#define MDNS_TTL 4500
+#endif
 
 uint32_t homekit_random() {
     return hwrand();

--- a/src/server.c
+++ b/src/server.c
@@ -39,10 +39,6 @@
 
 #define PORT 5556
 
-#ifndef MDNS_TTL
-#define MDNS_TTL 4500
-#endif
-
 #ifndef HOMEKIT_MAX_CLIENTS
 #define HOMEKIT_MAX_CLIENTS 16
 #endif


### PR DESCRIPTION
Added option to define another MDNS_TTL when building.