### PR TITLE
Fix int value casting on characteristics update

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2265,8 +2265,8 @@ void homekit_server_on_update_characteristics(client_context_t *context, const b
                         }
                     }
 
+                    h_value = HOMEKIT_INT(value);
                     h_value.format = ch->format;
-                    h_value.int_value = value;
                     if (ch->setter) {
                         ch->setter(h_value);
                     } else {


### PR DESCRIPTION
With the current way to cast updated characteristic values with int format, due to flag `h_value.is_bool` set to true characteristic updates with int value format aren't triggering the callback function