### PR TITLE
Bonjour improvements

### DIFF
--- a/src/mdnsresponder.c
+++ b/src/mdnsresponder.c
@@ -607,11 +607,11 @@ void mdns_add_facility( const char* instanceName,   // Friendly name, need not b
 
     sdk_os_timer_disarm(&mdns_announce_timer);
 
-    vTaskDelay(200); //while waiting for dhcp offer
+    while (sdk_wifi_station_get_connect_status() != STATION_GOT_IP) vTaskDelayMs(100);
     mdns_announce();
-    vTaskDelay(100);
+    vTaskDelayMs(1000);
     mdns_announce();
-    vTaskDelay(200);
+    vTaskDelayMs(2000);
     mdns_announce();
 
     sdk_os_timer_setfn(&mdns_announce_timer, mdns_announce, NULL);

--- a/src/mdnsresponder.c
+++ b/src/mdnsresponder.c
@@ -607,6 +607,11 @@ void mdns_add_facility( const char* instanceName,   // Friendly name, need not b
 
     sdk_os_timer_disarm(&mdns_announce_timer);
 
+    vTaskDelay(200); //while waiting for dhcp offer
+    mdns_announce();
+    vTaskDelay(100);
+    mdns_announce();
+    vTaskDelay(200);
     mdns_announce();
 
     sdk_os_timer_setfn(&mdns_announce_timer, mdns_announce, NULL);

--- a/src/server.c
+++ b/src/server.c
@@ -3115,10 +3115,12 @@ void homekit_setup_mdns(homekit_server_t *server) {
     }
 
     char unique_name[65]={0};
-    strncpy(unique_name, name->value.string_value, sizeof(unique_name)-4);
+    strncpy(unique_name, name->value.string_value, sizeof(unique_name)-6);
     unique_name[strlen(unique_name)]='-';
     unique_name[strlen(unique_name)]=server->accessory_id[0];
     unique_name[strlen(unique_name)]=server->accessory_id[1];
+    unique_name[strlen(unique_name)]=server->accessory_id[2];
+    unique_name[strlen(unique_name)]=server->accessory_id[3];
     homekit_mdns_configure_init(unique_name, PORT);
 
     // accessory model name (required)

--- a/src/server.c
+++ b/src/server.c
@@ -3114,7 +3114,12 @@ void homekit_setup_mdns(homekit_server_t *server) {
         return;
     }
 
-    homekit_mdns_configure_init(name->value.string_value, PORT);
+    char unique_name[65]={0};
+    strncpy(unique_name, name->value.string_value, sizeof(unique_name)-4);
+    unique_name[strlen(unique_name)]='-';
+    unique_name[strlen(unique_name)]=server->accessory_id[0];
+    unique_name[strlen(unique_name)]=server->accessory_id[1];
+    homekit_mdns_configure_init(unique_name, PORT);
 
     // accessory model name (required)
     homekit_mdns_add_txt("md", "%s", model->value.string_value);

--- a/src/server.c
+++ b/src/server.c
@@ -3119,8 +3119,8 @@ void homekit_setup_mdns(homekit_server_t *server) {
     unique_name[strlen(unique_name)]='-';
     unique_name[strlen(unique_name)]=server->accessory_id[0];
     unique_name[strlen(unique_name)]=server->accessory_id[1];
-    unique_name[strlen(unique_name)]=server->accessory_id[2];
     unique_name[strlen(unique_name)]=server->accessory_id[3];
+    unique_name[strlen(unique_name)]=server->accessory_id[4];
     homekit_mdns_configure_init(unique_name, PORT);
 
     // accessory model name (required)


### PR DESCRIPTION
This Pull Request aims to improve the bonjour name uniqueness by appending the 4 first digits of the accessoryID.
Also, it tests the availability of an IP address before transmitting the mdns announcement and then repeats it after 1 and another 2 seconds.
This is important for those systems that do not use the wifi-config since else the announcement is done with IP=0.0.0.0 and no visibility is achieved