### PR TITLE
Fixes No Response issue on ESP32

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3024,7 +3024,7 @@ void homekit_server_close_client(homekit_server_t *server, client_context_t *con
     // TODO: recalc server->max_fd ?
     server->nfds--;
 
-    lwip_close(context->socket);
+    close(context->socket);
 
     if (context->server->pairing_context && context->server->pairing_context->client == context) {
         pairing_context_free(context->server->pairing_context);
@@ -3060,7 +3060,7 @@ client_context_t *homekit_server_accept_client(homekit_server_t *server) {
 
     if (server->nfds > HOMEKIT_MAX_CLIENTS) {
         INFO("No more room for client connections (max %d)", HOMEKIT_MAX_CLIENTS);
-        lwip_close(s);
+        close(s);
         return NULL;
     }
 


### PR DESCRIPTION
See issue #84 that I reported.

To reproduce it, on fresh install I'd run `curl -v 192.168.1.56:5556/characteristics?id=1.10` several times (my device has that characteristic present).
After about 10 times, `homekit_server_accept_client` starts failing because the `accept` call returns `< 0`. After inspection, the `errno` set is 23, which means the socket is not getting properly closed.

As per https://github.com/espressif/esp-idf/pull/537, it seems that instead of `lwip_close` we need to be calling `lwip_close_r`, for threading issues. Since `lwip_close_r` is not present in esp-open-rtos, I changed the calls to `close`, that map to `lwip_close` on ESP8266 and to `lwip_close_r` on ESP32.

This fixed my "No Response" issue on an ESP32.