### PR TITLE
Fix debug on esp-idf and make it work with ESP8266_RTOS_SDK 3.2

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -19,7 +19,15 @@ typedef unsigned char byte;
 #define INFO(message, ...) printf(">>> HomeKit: " message "\n", ##__VA_ARGS__)
 #define ERROR(message, ...) printf("!!! HomeKit: " message "\n", ##__VA_ARGS__)
 
+#ifdef ESP_IDF
+
+#define DEBUG_HEAP() DEBUG("Free heap: %d", esp_get_free_heap_size());
+
+#else
+
 #define DEBUG_HEAP() DEBUG("Free heap: %d", xPortGetFreeHeapSize());
+
+#endif
 
 char *binary_to_string(const byte *data, size_t size);
 void print_binary(const char *prompt, const byte *data, size_t size);

--- a/src/port.c
+++ b/src/port.c
@@ -77,7 +77,6 @@ void homekit_mdns_configure_finalize() {
 #ifdef ESP_IDF
 
 #include <string.h>
-#include <esp_system.h>
 #include <mdns.h>
 
 uint32_t homekit_random() {

--- a/src/port.h
+++ b/src/port.h
@@ -15,6 +15,7 @@ void homekit_overclock_end();
 #endif
 
 #ifdef ESP_IDF
+#include <esp_system.h>
 #include <esp_spi_flash.h>
 #define SPI_FLASH_SECTOR_SIZE SPI_FLASH_SEC_SIZE
 #define spiflash_read(addr, buffer, size) (spi_flash_read((addr), (buffer), (size)) == ESP_OK)

--- a/src/server.c
+++ b/src/server.c
@@ -3076,7 +3076,7 @@ client_context_t *homekit_server_accept_client(homekit_server_t *server) {
     const int yes = 1; /* enable sending keepalive probes for socket */
     setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
 
-    const int idle = 180; /* 180 sec iddle before start sending probes */
+    const int idle = 180; /* 180 sec idle before start sending probes */
     setsockopt(s, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
 
     const int interval = 30; /* 30 sec between probes */


### PR DESCRIPTION
This repo actually works with Espressif's official ([ESP8266_RTOS_SDK v3.2](https://github.com/espressif/ESP8266_RTOS_SDK)) because both of them are in esp-idf compliant style (well, at least a lot of migration process has been done, and #ESP_IDF is defined in ESP8266 SDK now).

The rationale of moving`esp_system.h` to `port.h` is that `storage.c` requires `bool` `true` `false` definition included in `esp_system.h >> stdbool.h`

I've tested this in `esp-homekit-demo` with an additional header
`#include <driver/gpio.h>` and it actually compiles `esp-homekit-demo/esp32/led` example on ESP8266 and it works perfectly!

My menuconfig configuration:
```
Serial flasher config --->
    Default baud rate (115200 baud, maybe higher, I use 921600 to increase flash speed)
    'make monitor' baud rate (115200 bps)
    Flash Size (4MB, Mine is NodeMCU v3)
Component config --->
    ESP8266-specific --->
    (115200) UART console baud rate
    [ ] Initialize Task Watchdog Timer on startup
    [ ] Invoke panic handler on Task watchdog timeout
mDNS --->
    [*] Enable mDNS
```

Especially Task Watchdog part, if you don't disable it, during paring, the task will execute too long and the dog will bark and your kernel will panic.