### PR TITLE
Add spi_flash dependency to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(COMPONENT_ADD_INCLUDEDIRS
 
 set(COMPONENT_PRIV_INCLUDEDIRS "src")
 set(COMPONENT_SRCEXCLUDE "src/mdnsresponder.c")
-set(COMPONENT_REQUIRES wolfssl cJSON http-parser mdns)
+set(COMPONENT_REQUIRES wolfssl cJSON http-parser mdns spi_flash)
 
 register_component()
 


### PR DESCRIPTION
Add dependency to spi_flash to CMake as this has been
moved into a component on the ESP-IDF 4.0 release branch.