### PR TITLE
Mirror change made to make to use built-in JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(COMPONENT_ADD_INCLUDEDIRS
 
 set(COMPONENT_PRIV_INCLUDEDIRS "src")
 set(COMPONENT_SRCEXCLUDE "src/mdnsresponder.c")
-set(COMPONENT_REQUIRES wolfssl cJSON http-parser mdns)
+set(COMPONENT_REQUIRES wolfssl json http-parser mdns)
 
 register_component()
 


### PR DESCRIPTION
This changes to use the ESP32-IDF built in JSON that was already made in the make file.
