### PR TITLE
reset http_parser if required

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3698,6 +3698,15 @@ static void homekit_client_process(client_context_t *context) {
             &context->server->parser, &homekit_http_parser_settings,
             (char *)payload, payload_size
         );
+
+        CLIENT_DEBUG(context, "Parser state: %d, error %s: %s", context->server->parser.state,
+                        http_errno_name(context->server->parser.http_errno),
+                        http_errno_description(context->server->parser.http_errno));
+        if ( context->server->parser.state == 1 ) {
+                CLIENT_DEBUG(context, "Reset parser");
+                http_parser_init(&context->server->parser, HTTP_REQUEST);
+        }
+
     } while (data_available && !context->server->request_completed);
 
     current_client_context = NULL;


### PR DESCRIPTION
If the parser sees a "Connection: Close" message it will not process any subsequent requests. This modification checks for that status and resets the parser. This was first seen when resetting Homebridge on a Raspberry PI, but could equally be exploited by anyone who has access to send http message in the clear to your accessories